### PR TITLE
I fixed the correct class to render HTML in newer versions

### DIFF
--- a/includes/SpecialSpringboard.php
+++ b/includes/SpecialSpringboard.php
@@ -13,7 +13,7 @@
 namespace MediaWiki\Extension\Springboard;
 
 use ExtensionRegistry;
-use Html\Html;
+use MediaWiki\Html\Html;
 use PermissionsError;
 use SpecialPage;
 use Symfony\Component\Yaml\Yaml;


### PR DESCRIPTION
Fixed bug that prevents the page from starting in MW versions 1.43+