### PR TITLE
Make "distribution list" URL a specific revision

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -23,7 +23,7 @@
 		"springboard"
 	],
 	"config": {
-		"SBDistributionListURL": "https://www.mediawiki.org/wiki/Recommended_revisions/1.43"
+		"SBDistributionListURL": "https://www.mediawiki.org/wiki/Recommended_revisions/1.43?oldid=7608672&action=raw"
 	},
 	"SpecialPages": {
 		"Springboard": {


### PR DESCRIPTION
This is very important, because otherwise the list can be changed at any time - by either malicious users or simply users trying to improve the list but with negative results.