### PR TITLE
Turn URL setting into per-MediaWiki-version array

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -23,7 +23,9 @@
 		"springboard"
 	],
 	"config": {
-		"SBDistributionListURL": "https://www.mediawiki.org/wiki/Recommended_revisions/1.43?oldid=7608672&action=raw"
+		"SBDistributionListURL": {
+			"1.43": "https://www.mediawiki.org/wiki/Recommended_revisions/1.43?oldid=7608672&action=raw"
+		}
 	},
 	"SpecialPages": {
 		"Springboard": {

--- a/includes/SpecialSpringboard.php
+++ b/includes/SpecialSpringboard.php
@@ -94,7 +94,17 @@ class SpecialSpringboard extends SpecialPage {
 	 */
 	private function fetchRecommendedPage() {
 		$configURL = $this->getConfig()->get( 'SBDistributionListURL' );
-		$wikitext = file_get_contents( $configURL );
+		if ( is_array( $configURL ) ) {
+			$wikitext = false;
+			// Get e.g. "1.23" from "1.23.4-alpha"
+			preg_match("/^\d\.\d+/", MW_VERSION, $match);
+			$currentVersion = $match[0];
+			if ( array_key_exists( $currentVersion, $configURL ) ) {
+				$wikitext = file_get_contents( $configURL[$currentVersion] );
+			}
+		} else {
+			$wikitext = file_get_contents( $configURL );
+		}
 		if ( $wikitext === false ) {
 			return [ 'extension' => [], 'skin' => [] ];
 		}


### PR DESCRIPTION
That way, a single version of this extension can run on mulitple MediaWiki versions at the same time.

However, also allow admins to simply set this variable to a string (URL).