### PR TITLE
Add setHeaders() call to Special:Springboard

### DIFF
--- a/includes/SpecialSpringboard.php
+++ b/includes/SpecialSpringboard.php
@@ -33,6 +33,7 @@ class SpecialSpringboard extends SpecialPage {
 	}
 
 	public function execute( $query ) {
+		$this->setHeaders();
 		$user = $this->getUser();
 		if ( !$user->isAllowed( 'springboard' ) ) {
 			throw new PermissionsError( 'springboard' );


### PR DESCRIPTION
This enables the page name to show up.