### PR TITLE
Add translations for Springboard in multiple languages

### DIFF
--- a/i18n/de.json
+++ b/i18n/de.json
@@ -1,0 +1,16 @@
+{
+	"@metadata": {
+		"authors": [
+			"Daniel Yepez Garces"
+		]
+	},
+	"springboard": "Springboard",
+	"springboard-desc": "Ermöglicht es Benutzern, Erweiterungen und Skins in ihrem Wiki zu installieren",
+	"springboard-extensions-tab-name": "Erweiterungen",
+	"springboard-skins-tab-name": "Skins",
+	"springboard-api-error-loadedelsewhere": "$1 ist bereits woanders geladen (LocalSettings.php)",
+	"springboard-api-error-alreadyinstalled": "$1 ist bereits installiert",
+	"springboard-api-error-notinstalled": "$1 ist nicht installiert",
+	"springboard-api-error-invalidtype": "Ungültiger Typ. Verfügbare Typen => [extension, skin]",
+	"springboard-api-error-composerfile": "Die Datei composer.json konnte in $1 nicht gefunden werden"
+}

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -1,0 +1,16 @@
+{
+	"@metadata": {
+		"authors": [
+			"Daniel Yepez Garces"
+		]
+	},
+	"springboard": "Springboard",
+	"springboard-desc": "Kullanıcıların wiki'lerine eklentiler ve temalar yüklemelerine olanak tanır",
+	"springboard-extensions-tab-name": "Eklentiler",
+	"springboard-skins-tab-name": "Temalar",
+	"springboard-api-error-loadedelsewhere": "$1 başka bir yerde zaten yüklendi (LocalSettings.php)",
+	"springboard-api-error-alreadyinstalled": "$1 zaten yüklü",
+	"springboard-api-error-notinstalled": "$1 yüklü değil",
+	"springboard-api-error-invalidtype": "Geçersiz tür. Mevcut türler => [extension, skin]",
+	"springboard-api-error-composerfile": "$1 içinde composer.json dosyası bulunamadı"
+}

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -1,0 +1,16 @@
+{
+	"@metadata": {
+		"authors": [
+			"Daniel Yepez Garces"
+		]
+	},
+	"springboard": "Springboard",
+	"springboard-desc": "Permet aux utilisateurs d'installer des extensions et des thèmes dans leur wiki",
+	"springboard-extensions-tab-name": "Extensions",
+	"springboard-skins-tab-name": "Thèmes",
+	"springboard-api-error-loadedelsewhere": "$1 est déjà chargé ailleurs (LocalSettings.php)",
+	"springboard-api-error-alreadyinstalled": "$1 est déjà installé",
+	"springboard-api-error-notinstalled": "$1 n'est pas installé",
+	"springboard-api-error-invalidtype": "Type invalide. Types disponibles => [extension, skin]",
+	"springboard-api-error-composerfile": "Impossible de trouver le fichier composer.json dans $1"
+}

--- a/i18n/it.json
+++ b/i18n/it.json
@@ -1,0 +1,16 @@
+{
+	"@metadata": {
+		"authors": [
+			"Daniel Yepez Garces"
+		]
+	},
+	"springboard": "Springboard",
+	"springboard-desc": "Permette agli utenti di installare estensioni e temi nel loro wiki",
+	"springboard-extensions-tab-name": "Estensioni",
+	"springboard-skins-tab-name": "Temi",
+	"springboard-api-error-loadedelsewhere": "$1 è già caricato altrove (LocalSettings.php)",
+	"springboard-api-error-alreadyinstalled": "$1 è già installato",
+	"springboard-api-error-notinstalled": "$1 non è installato",
+	"springboard-api-error-invalidtype": "Tipo non valido. Tipi disponibili => [extension, skin]",
+	"springboard-api-error-composerfile": "Impossibile trovare il file composer.json in $1"
+}

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -1,0 +1,16 @@
+{
+	"@metadata": {
+		"authors": [
+			"Daniel Yepez Garces"
+		]
+	},
+	"springboard": "Springboard",
+	"springboard-desc": "ユーザーがウィキに拡張機能やスキンをインストールできるようにします",
+	"springboard-extensions-tab-name": "拡張機能",
+	"springboard-skins-tab-name": "スキン",
+	"springboard-api-error-loadedelsewhere": "$1は他の場所ですでに読み込まれています（LocalSettings.php）",
+	"springboard-api-error-alreadyinstalled": "$1はすでにインストールされています",
+	"springboard-api-error-notinstalled": "$1はインストールされていません",
+	"springboard-api-error-invalidtype": "無効なタイプです。利用可能なタイプ => [extension, skin]",
+	"springboard-api-error-composerfile": "$1にcomposer.jsonファイルが見つかりませんでした"
+}

--- a/i18n/pl.json
+++ b/i18n/pl.json
@@ -1,0 +1,16 @@
+{
+	"@metadata": {
+		"authors": [
+			"Daniel Yepez Garces"
+		]
+	},
+	"springboard": "Springboard",
+	"springboard-desc": "Pozwala użytkownikom na instalowanie rozszerzeń i skórek w ich wiki",
+	"springboard-extensions-tab-name": "Rozszerzenia",
+	"springboard-skins-tab-name": "Skórki",
+	"springboard-api-error-loadedelsewhere": "$1 jest już załadowany gdzie indziej (LocalSettings.php)",
+	"springboard-api-error-alreadyinstalled": "$1 jest już zainstalowany",
+	"springboard-api-error-notinstalled": "$1 nie jest zainstalowany",
+	"springboard-api-error-invalidtype": "Nieprawidłowy typ. Dostępne typy => [extension, skin]",
+	"springboard-api-error-composerfile": "Nie udało się znaleźć pliku composer.json w $1"
+}

--- a/i18n/pt.json
+++ b/i18n/pt.json
@@ -1,0 +1,16 @@
+{
+	"@metadata": {
+		"authors": [
+			"Daniel Yepez Garces"
+		]
+	},
+	"springboard": "Springboard",
+	"springboard-desc": "Permite que os usuários instalem extensões e temas em seu wiki",
+	"springboard-extensions-tab-name": "Extensões",
+	"springboard-skins-tab-name": "Temas",
+	"springboard-api-error-loadedelsewhere": "$1 já está carregado em outro lugar (LocalSettings.php)",
+	"springboard-api-error-alreadyinstalled": "$1 já está instalado",
+	"springboard-api-error-notinstalled": "$1 não está instalado",
+	"springboard-api-error-invalidtype": "Tipo inválido. Tipos disponíveis => [extension, skin]",
+	"springboard-api-error-composerfile": "Não foi possível encontrar o arquivo composer.json em $1"
+}

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -1,0 +1,16 @@
+{
+	"@metadata": {
+		"authors": [
+			"Daniel Yepez Garces"
+		]
+	},
+	"springboard": "Springboard",
+	"springboard-desc": "Позволяет пользователям устанавливать расширения и скины в их вики",
+	"springboard-extensions-tab-name": "Расширения",
+	"springboard-skins-tab-name": "Скины",
+	"springboard-api-error-loadedelsewhere": "$1 уже загружен в другом месте (LocalSettings.php)",
+	"springboard-api-error-alreadyinstalled": "$1 уже установлен",
+	"springboard-api-error-notinstalled": "$1 не установлен",
+	"springboard-api-error-invalidtype": "Неверный тип. Доступные типы => [extension, skin]",
+	"springboard-api-error-composerfile": "Не удалось найти файл composer.json в $1"
+}

--- a/i18n/sr.json
+++ b/i18n/sr.json
@@ -1,0 +1,16 @@
+{
+	"@metadata": {
+		"authors": [
+			"Daniel Yepez Garces"
+		]
+	},
+	"springboard": "Springboard",
+	"springboard-desc": "Omogućava korisnicima da instaliraju ekstenzije i teme u njihovom vikiju",
+	"springboard-extensions-tab-name": "Ekstenzije",
+	"springboard-skins-tab-name": "Teme",
+	"springboard-api-error-loadedelsewhere": "$1 je već učitan na drugom mestu (LocalSettings.php)",
+	"springboard-api-error-alreadyinstalled": "$1 je već instaliran",
+	"springboard-api-error-notinstalled": "$1 nije instaliran",
+	"springboard-api-error-invalidtype": "Nevažeći tip. Dostupni tipovi => [extension, skin]",
+	"springboard-api-error-composerfile": "Nije moguće pronaći composer.json fajl u $1"
+}

--- a/i18n/tr.json
+++ b/i18n/tr.json
@@ -1,0 +1,16 @@
+{
+	"@metadata": {
+		"authors": [
+			"Daniel Yepez Garces"
+		]
+	},
+	"springboard": "Springboard",
+	"springboard-desc": "Kullanıcıların wiki'lerine eklentiler ve temalar yüklemelerine olanak tanır",
+	"springboard-extensions-tab-name": "Eklentiler",
+	"springboard-skins-tab-name": "Temalar",
+	"springboard-api-error-loadedelsewhere": "$1 başka bir yerde zaten yüklendi (LocalSettings.php)",
+	"springboard-api-error-alreadyinstalled": "$1 zaten yüklü",
+	"springboard-api-error-notinstalled": "$1 yüklü değil",
+	"springboard-api-error-invalidtype": "Geçersiz tür. Mevcut türler => [extension, skin]",
+	"springboard-api-error-composerfile": "$1 içinde composer.json dosyası bulunamadı"
+}

--- a/i18n/zh.json
+++ b/i18n/zh.json
@@ -1,0 +1,16 @@
+{
+	"@metadata": {
+		"authors": [
+			"Daniel Yepez Garces"
+		]
+	},
+	"springboard": "Springboard",
+	"springboard-desc": "允许用户在他们的维基中安装扩展和皮肤",
+	"springboard-extensions-tab-name": "扩展",
+	"springboard-skins-tab-name": "皮肤",
+	"springboard-api-error-loadedelsewhere": "$1 已经在其他地方加载（LocalSettings.php）",
+	"springboard-api-error-alreadyinstalled": "$1 已经安装",
+	"springboard-api-error-notinstalled": "$1 尚未安装",
+	"springboard-api-error-invalidtype": "无效的类型。可用类型 => [extension, skin]",
+	"springboard-api-error-composerfile": "无法在 $1 中找到 composer.json 文件"
+}


### PR DESCRIPTION
This PR adds translations for the Springboard extension in several languages, including:
- Spanish (es)
- Portuguese (pt)
- Italian (it)
- French (fr)
- German (de)
- Japanese (ja)
- Chinese (zh)
- Russian (ru)
- Polish (pl)
- Serbian (sr)
-  Turkish (tr)